### PR TITLE
Create alias for 'locks' command

### DIFF
--- a/locker.py
+++ b/locker.py
@@ -91,6 +91,23 @@ class Locker(BotPlugin):
         """
         List all locked objects.
         """
+        locked_items = self._locks(message=message, args=args)
+        for lock in locked_items:
+            yield lock
+
+    @botcmd
+    def locked(self, message, args):
+        """
+        List all locked objects.
+        """
+        locked_items = self._locks(message=message, args=args)
+        for lock in locked_items:
+            yield lock
+
+    def _locks(self, message, args):
+        """
+        List all locked objects.
+        """
         with self.threadlock:
             if len(self['locks']) == 0:
                 yield "Nothing is currently locked"

--- a/locker.py
+++ b/locker.py
@@ -109,7 +109,7 @@ class Locker(BotPlugin):
         List all locked objects.
         """
         with self.threadlock:
-            if len(self['locks']) == 0:
+            if not self['locks']:
                 yield "Nothing is currently locked"
                 return
 


### PR DESCRIPTION
We tend to normally type `locked` instead of `locks` when trying to refer what is currently locked.

There's no alias type feature in errbot-core, so I put this together to get that functionality.