### PR TITLE
Human readable output when a lock was created

### DIFF
--- a/locker.py
+++ b/locker.py
@@ -1,5 +1,7 @@
 import datetime
 import threading
+
+import pendulum
 from errbot import BotPlugin, arg_botcmd, botcmd, re_botcmd
 
 
@@ -97,10 +99,12 @@ class Locker(BotPlugin):
                 return
 
             for lock, details in self['locks'].items():
-                yield "{0} locked by {1[by]} on {1[at]} ({1[message]})".format(
-                    lock,
-                    details
-                )
+                ago = pendulum.instance(details['at']).diff_for_humans()
+                details.update({
+                    'lock': lock,
+                    'ago': ago,
+                })
+                yield "{lock} locked by {by} {ago} on {at} ({message})".format_map(details)
 
     @re_botcmd(pattern=r'^lock ([\w]+)( |\.)?$', prefixed=False)
     def re_lock(self, message, match):

--- a/locker.py
+++ b/locker.py
@@ -42,9 +42,11 @@ class Locker(BotPlugin):
                 if locks[what]['by'] == by:
                     return "You already locked this"
                 else:
-                    return "{what} is already locked by {who} and must be unlocked first".format(
+                    ago = pendulum.instance(locks[what]['at']).diff_for_humans()
+                    return "{what} is already locked by {who} ({ago}) and must be unlocked first".format(
                         what=what,
-                        who=locks[what]['by']
+                        who=locks[what]['by'],
+                        ago=ago,
                     )
 
             locks[what] = {
@@ -73,9 +75,11 @@ class Locker(BotPlugin):
                 return "{} unlocked".format(what)
             else:
                 if not force:
-                    return "{what} was locked by {who}, not unlocking without --force".format(
+                    ago = pendulum.instance(lock['at']).diff_for_humans()
+                    return "{what} was locked by {who} ({ago}), not unlocking without --force".format(
                         what=what,
-                        who=lock['by']
+                        who=lock['by'],
+                        ago=ago,
                     )
                 else:
                     del locks[what]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pendulum


### PR DESCRIPTION
Try and get some relative time output when a lock was created.

Sometimes it is hard to relate when a lock was created and manually trying to understand if that was a few minutes, a couple of hours or maybe even a day or two can be a problem.

The `!locks` output would now be
```
[@saviles ➡ @errbot] >>> !locks
something locked by CHANGE_ME 5 hours ago on 2018-08-25 22:52:17.114810 (No reason specified)
something1 locked by CHANGE_ME 5 hours ago on 2018-08-25 22:52:24.631506 (No reason specified)
myself locked by sijis 5 hours ago on 2018-08-25 22:52:35.717073 (No reason specified)
```

Locking something that is owned by someone else
```
[@zoni ➡ @errbot] >>> !lock myself
myself is already locked by sijis (6 hours ago) and must be unlocked first
```

Unlocking something owned by someone else
```
[@zoni ➡ @errbot] >>> !unlock myself
myself was locked by sijis (6 hours ago), not unlocking without --force
```